### PR TITLE
Unannounce single service type from node

### DIFF
--- a/discovery-server/src/main/java/io/airlift/discovery/server/DynamicAnnouncementResource.java
+++ b/discovery-server/src/main/java/io/airlift/discovery/server/DynamicAnnouncementResource.java
@@ -74,4 +74,13 @@ public class DynamicAnnouncementResource
 
         return Response.noContent().build();
     }
+
+    @DELETE
+    @Path("{app_type}")
+    public Response delete(@PathParam("node_id") Id<Node> nodeId, @PathParam("app_type") String applicationType)
+    {
+        dynamicStore.delete(nodeId, applicationType);
+
+        return Response.noContent().build();
+    }
 }

--- a/discovery-server/src/main/java/io/airlift/discovery/server/DynamicStore.java
+++ b/discovery-server/src/main/java/io/airlift/discovery/server/DynamicStore.java
@@ -21,6 +21,7 @@ public interface DynamicStore
 {
     void put(Id<Node> nodeId, DynamicAnnouncement announcement);
     void delete(Id<Node> nodeId);
+    void delete(Id<Node> nodeId, String applicationType);
 
     Set<Service> getAll();
     Set<Service> get(String type);

--- a/discovery-server/src/main/java/io/airlift/discovery/server/ReplicatedStaticStore.java
+++ b/discovery-server/src/main/java/io/airlift/discovery/server/ReplicatedStaticStore.java
@@ -21,7 +21,6 @@ import io.airlift.discovery.store.Entry;
 import io.airlift.json.JsonCodec;
 
 import javax.inject.Inject;
-
 import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkNotNull;

--- a/discovery-server/src/test/java/io/airlift/discovery/server/InMemoryDynamicStore.java
+++ b/discovery-server/src/test/java/io/airlift/discovery/server/InMemoryDynamicStore.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static com.google.common.base.Predicates.and;
+import static com.google.common.base.Predicates.not;
 import static com.google.common.collect.Collections2.transform;
 import static com.google.common.collect.Iterables.filter;
 import static io.airlift.discovery.server.DynamicServiceAnnouncement.toServiceWith;
@@ -69,6 +70,19 @@ public class InMemoryDynamicStore
         Preconditions.checkNotNull(nodeId, "nodeId is null");
 
         descriptors.remove(nodeId);
+    }
+
+    @Override
+    public synchronized void delete(Id<Node> nodeId, String applicationType)
+    {
+        Preconditions.checkNotNull(nodeId, "nodeId is null");
+
+        Entry old = descriptors.get(nodeId);
+        if (old == null) {
+            return;
+        }
+        Entry updated = new Entry(old.getExpiration(), ImmutableSet.copyOf(filter(old.getServices(), not(matchesType(applicationType)))));
+        descriptors.put(nodeId, updated);
     }
 
     @Override


### PR DESCRIPTION
Previous to this commit a node can announce multiple services at once, but
unannounce was limited to removing the node entire. This is problematic when
you want to turn off some aspect of a service (possibly for graceful shutdown)
while leaving other aspects running.
