### PR TITLE
Fix serialization name in Entry

### DIFF
--- a/discovery-server/src/main/java/io/airlift/discovery/store/Entry.java
+++ b/discovery-server/src/main/java/io/airlift/discovery/store/Entry.java
@@ -36,7 +36,7 @@ public class Entry
             @JsonProperty("value") byte[] value,
             @JsonProperty("version") Version version, 
             @JsonProperty("timestamp") long timestamp,
-            @JsonProperty("maxAge") Long maxAgeInMs)
+            @JsonProperty("maxAgeInMs") Long maxAgeInMs)
     {
         Preconditions.checkNotNull(key, "key is null");
         Preconditions.checkNotNull(version, "version is null");

--- a/discovery-server/src/test/java/io/airlift/discovery/store/TestEntry.java
+++ b/discovery-server/src/test/java/io/airlift/discovery/store/TestEntry.java
@@ -25,13 +25,13 @@ public class TestEntry
     @Test
     public void testEntry()
     {
-        Entry entry = entryOf("fruit", "apple", 123, 456);
+        Entry entry = entryOf("fruit", "apple", 123, 456, 3000L);
 
         assertEquals(entry.getKey(), "fruit".getBytes(UTF_8));
         assertEquals(entry.getValue(), "apple".getBytes(UTF_8));
         assertEquals(entry.getVersion().getSequence(), 123);
         assertEquals(entry.getTimestamp(), 456);
-        assertEquals(entry.getMaxAgeInMs(), null);
+        assertEquals(entry.getMaxAgeInMs(), Long.valueOf(3000L));
     }
 
     @Test
@@ -40,14 +40,14 @@ public class TestEntry
     {
         JsonCodec<Entry> codec = jsonCodec(Entry.class);
 
-        Entry expected = entryOf("fruit", "apple", 123, 456);
+        Entry expected = entryOf("fruit", "apple", 123, 456, 3000L);
         Entry actual = codec.fromJson(codec.toJsonBytes(expected));
 
         assertEquals(actual, expected);
     }
 
-    private static Entry entryOf(String key, String value, long version, long timestamp)
+    private static Entry entryOf(String key, String value, long version, long timestamp, Long maxAgeInMs)
     {
-        return new Entry(key.getBytes(UTF_8), value.getBytes(UTF_8), new Version(version), timestamp, null);
+        return new Entry(key.getBytes(UTF_8), value.getBytes(UTF_8), new Version(version), timestamp, maxAgeInMs);
     }
 }


### PR DESCRIPTION
The `maxAgeInMs` property in Entry class is serialized with the name `maxAgeInMs` but deserialized as `maxAge`. That leads to such a problem: in a multiple-node discovery service deployment, an entry sync from other node might never expire as its `maxAgeInMs` is always null.